### PR TITLE
Fix polyframe

### DIFF
--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -18,10 +18,10 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
     stop(paste0('theta0 length (', length(theta0), ') is inconsistent with the number of parameters (', znum + fnum + snum, ')'), sep = '')
   }
   if (!is.null(zX)) {
-    polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
+    polyframe <- poly(matrix(cbind(fX,sX,pX), ncol = fnum + snum + ncol(pX)),degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
     regvars <- cbind(fX,sX,zX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } else { 
-    polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) 
+    polyframe <- poly(matrix(cbind(fX,sX,pX), ncol = fnum + snum + ncol(pX)),degree=G,raw=!orth)
     regvars <- cbind(fX,sX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } # create (orthogonal / raw) polynomial of degree G
   if (dum) {regvars <- cbind(regvars, factor(timevar))} # add time dummies to first stage


### PR DESCRIPTION
If snum or fnum or ncol(pX) are bigger then one, poly frame will throw an error (to see this, run your example with two flexible inputs). 
Calling it inside a matrix fixes this.