### PR TITLE
Fixed bootstrapped s.e.s in ACF and OPLP

### DIFF
--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -18,7 +18,7 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
     stop(paste0('theta0 length (', length(theta0), ') is inconsistent with the number of parameters (', znum + fnum + snum, ')'), sep = '')
   }
   if (!is.null(zX)) {
-    polyframe <- poly(fX,sX,zX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
+    polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
     regvars <- cbind(fX,sX,zX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } else { 
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) 

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -60,12 +60,12 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
     nCores = NULL
     boot.betas <- matrix(unlist(
       lapply(boot.indices, finalACF, data = data, fnum = fnum, snum = snum, znum = znum, opt = opt,
-             theta0 = theta0, boot = TRUE)), ncol = fnum + snum + znum, byrow = TRUE) # use the indices and pass them to the final function (reshape the data)
+             theta0 = theta0, A = A, boot = TRUE)), ncol = fnum + snum + znum, byrow = TRUE) # use the indices and pass them to the final function (reshape the data)
   } else {
     nCores = length(cluster)
     clusterEvalQ(cl = cluster, library(prodest))
     boot.betas <- matrix( unlist( parLapply(cl = cluster, boot.indices, finalACF, data = data, fnum = fnum, snum = snum,
-                                            znum = znum, opt = opt, theta0 = theta0, boot = TRUE) ),
+                                            znum = znum, opt = opt, theta0 = theta0, A = A, boot = TRUE) ),
                           ncol = fnum + snum + znum, byrow = TRUE ) # use the indices and pass them to the final function (reshape the data)
   }
   boot.errors <- apply(boot.betas, 2, sd, na.rm = TRUE) # calculate standard deviations

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -19,7 +19,7 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
   }
   if (!is.null(zX)) {
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
-    regvars <- cbind(fX,sX,zX,pX,fX*zX,sX*zX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
+    regvars <- cbind(fX,sX,zX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } else { 
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) 
     regvars <- cbind(fX,sX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -160,6 +160,7 @@ gACF <- function(theta, mZ, mW, mX, mlX, vphi, vlag.phi, A){
   Omega <- vphi - mX %*% theta
   Omega_lag <- vlag.phi - mlX %*% theta
   Omega_lag_pol <- poly(Omega_lag,degree=A,raw=T) # create polynomial in omega for given degree
+  Omega_lag_pol <- cbind(1, Omega_lag_pol)
   g_b <- solve(crossprod(Omega_lag_pol)) %*% t(Omega_lag_pol) %*% Omega
   XI <- Omega - Omega_lag_pol %*% g_b
   crit <- t(crossprod(mZ, XI)) %*% mW %*% (crossprod(mZ, XI))

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -18,7 +18,7 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
     stop(paste0('theta0 length (', length(theta0), ') is inconsistent with the number of parameters (', znum + fnum + snum, ')'), sep = '')
   }
   if (!is.null(zX)) {
-    polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
+    polyframe <- poly(fX,sX,zX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
     regvars <- cbind(fX,sX,zX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } else { 
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) 

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -160,7 +160,6 @@ gACF <- function(theta, mZ, mW, mX, mlX, vphi, vlag.phi, A){
   Omega <- vphi - mX %*% theta
   Omega_lag <- vlag.phi - mlX %*% theta
   Omega_lag_pol <- poly(Omega_lag,degree=A,raw=T) # create polynomial in omega for given degree
-  Omega_lag_pol <- cbind(1, Omega_lag_pol)
   g_b <- solve(crossprod(Omega_lag_pol)) %*% t(Omega_lag_pol) %*% Omega
   XI <- Omega - Omega_lag_pol %*% g_b
   crit <- t(crossprod(mZ, XI)) %*% mW %*% (crossprod(mZ, XI))

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -19,7 +19,7 @@ prodestACF <- function(Y, fX, sX, pX, idvar, timevar, zX = NULL, control = 'none
   }
   if (!is.null(zX)) {
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) # create (orthogonal / raw) polynomial of degree G
-    regvars <- cbind(fX,sX,zX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
+    regvars <- cbind(fX,sX,zX,pX,fX*zX,sX*zX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)
   } else { 
     polyframe <- poly(fX,sX,pX,degree=G,raw=!orth) 
     regvars <- cbind(fX,sX,pX,polyframe) # to make sure 1st degree variables come first (lm will drop the other ones from 1st-stage reg)

--- a/prodest/R/prodestACF.R
+++ b/prodest/R/prodestACF.R
@@ -114,7 +114,7 @@ finalACF <- function(ind, data, fnum, snum, znum, opt, theta0, A, boot = FALSE){
     try.out <- try(optim(theta0, gACF, method = "BFGS", mZ = tmp.data$Z, mW = W, mX = tmp.data$X,
                          mlX = tmp.data$lX,
                          vphi = tmp.data$phi, vlag.phi = tmp.data$lag.phi, A = A,
-                         control = list(maxit = 1500) # to 'guarantee' 2nd stage convergence
+                         control = list(maxit = 2000) # to 'guarantee' 2nd stage convergence
                          ), silent = TRUE)
     if (!inherits(try.out, "try-error")) {
       betas <- try.out$par

--- a/prodest/R/prodestOPLP.R
+++ b/prodest/R/prodestOPLP.R
@@ -98,15 +98,15 @@ prodestLP <- function(Y, fX, sX, pX, idvar, timevar, R = 20, cX = NULL, opt = 'o
     boot.betas <- matrix(NA, R, (fnum + snum + cnum))
     for (i in 1:R){
       boot.betas[i,] <- finalOPLP(ind = boot.indices[[i]], data = data, fnum = fnum, snum = snum, cnum = cnum,
-                                  opt = opt, theta0 = theta0, boot = TRUE, tol = tol)
+                                  opt = opt, theta0 = theta0, A = A, boot = TRUE, tol = tol)
     }
   } else { # set up the cluster: send the lag Panel and the data.table libraries to clusters
     nCores = length(cluster)
     clusterEvalQ(cl = cluster, library(prodest))
     boot.betas <- matrix(unlist(parLapply(cl = cluster, boot.indices, finalOPLP, data = data,
                                           fnum = fnum, snum = snum, cnum = cnum,
-                                          opt = opt, theta0 = theta0, boot = TRUE, tol = tol)), ncol = fnum + snum + cnum,
-                         byrow = TRUE) # use the indices and pass them to the final function (reshape the data)
+                                          opt = opt, theta0 = theta0, A = A, boot = TRUE, tol = tol)), 
+                         ncol = fnum + snum + cnum, byrow = TRUE) # use the indices and pass them to the final function (reshape the data)
   }
   boot.errors <- apply(boot.betas, 2, sd, na.rm = TRUE) # calculate standard deviations
   res.names <- c(colnames(fX, do.NULL = FALSE, prefix = 'fX'),


### PR DESCRIPTION
I forgot to pass A to finalACF and finalOP/LP when bootstrapping, so SEs would come out as NA. 

This includes pull request #16 by RicoDiel, but also fixes it for OP/LP.